### PR TITLE
Java

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     packages=find_packages(exclude=["*tests*", "*docs*", "*binder*", "*conda*", "*notebooks*", "*.ci_support*"]),
     install_requires=[
         'numpy',
-        'openjdk',
         'owlready2',
         'pandas',
         'pint',

--- a/tests/unit/test_tree.py
+++ b/tests/unit/test_tree.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+import pyiron_ontology
+
+
+class TestTree(TestCase):
+    def test_construction(self):
+        # Just a simple test based on the current status of the ontology to make sure
+        # the basics are working
+        # Don't take this test too seriously, it's not asserting a promised interface,
+        # it's just making sure I can actually do stuff on the CI.
+
+        onto = pyiron_ontology.dynamic.atomistics()
+        tree = pyiron_ontology.build_tree(onto.Bulk_modulus)
+
+        while len(tree.children) > 0:
+            tree = tree.children[0]
+
+        self.assertEqual(onto["CreateStructureBulk/output/structure"], tree.value)


### PR DESCRIPTION
I'm an idiot. I thought the pip-check was failing because pyiron_ontology wasn't on pypi yet. If I'd taken a moment to read the log, I would have seen that it fails because it can't find `openjdk`, which it can't find because it doesn't exist! The closest thing is a python library that allows you to install jdk.

So I'm just purging it from setup.py (and leaving it in the conda env). Since it's still in the conda env, I don't anticipate any trouble with the CI, but it means anyone who installs via pypi may need to make sure they have JDK on their own.