### PR TITLE
Coveralls auth

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,9 +23,12 @@ jobs:
           test-dir: tests
       - name: Coverage
         shell: bash -l {0}
+        env:
+          COVERALLS_SERVICE_NAME: 'github'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           coverage combine
-          coveralls
+          coveralls --service=github
           coverage xml
       - name: Codacy
         shell: bash -l {0}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,7 +4,7 @@ name: Daily
 
 on:
   schedule:
-    - cron: '00 23 * * *'
+    - cron: '00 19 * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Still trying to get coveralls authentification to work. The current setup is the same as base and atomistics, so I'm surprised I'm still getting the error. Here I just try re-introducing the `service` flag. If this _still_ fails I'll try once more removing and re-adding the repo on coveralls.... after that I'm honestly out of attacks, so hopefully this works soon.