### PR TITLE
Unpin sqlalchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pandas',
         'pint',
         'pyiron_atomistics>=0.2.63',
-        'sqlalchemy==1.4.46',
+        'sqlalchemy',
     ],
     cmdclass=versioneer.get_cmdclass(),
 


### PR DESCRIPTION
The indirect upstream dependency (pyiron_base) also un-pins it, so I think we're probably ok now.