### PR TITLE
Remove explicit sqlalchemy dependence

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,6 +7,5 @@ dependencies:
 - pandas
 - pint
 - pyiron_atomistics >=0.2.63
-- sqlalchemy =2.0.9
 - python >= 3.8
 - lammps

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pandas
   - pint
   - pyiron_atomistics >=0.2.63
-  - sqlalchemy
+  - sqlalchemy =2.0.9

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - pandas
   - pint
   - pyiron_atomistics >=0.2.63
-  - sqlalchemy =2.0.9

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,4 +9,3 @@ dependencies:
 - pandas
 - pint
 - pyiron_atomistics >=0.2.63
-- sqlalchemy =2.0.9

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'pandas',
         'pint',
         'pyiron_atomistics>=0.2.63',
-        'sqlalchemy==2.0.9',
     ],
     cmdclass=versioneer.get_cmdclass(),
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pandas',
         'pint',
         'pyiron_atomistics>=0.2.63',
-        'sqlalchemy',
+        'sqlalchemy==2.0.9',
     ],
     cmdclass=versioneer.get_cmdclass(),
 


### PR DESCRIPTION
[previously](https://github.com/pyiron/core/discussions/1#discussioncomment-5234174) this needed an explicit pin <2 to satisfy mendeleev. Now, however, it looks like they are [explicitly pinning 2.0.9](https://github.com/lmmentel/mendeleev/blob/04cfe2ce58734f18fefee658a44722ef49b0c7f9/poetry.lock#L3306), so I would be a bit surprised if this was the source of the trouble. However, previously it was a conda/pypi mismatch and they're using poetry (which I'm not so familiar with) so maybe such a mismatch persists?