### PR TITLE
Directly invoke the updated centralized coverage call

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -1,0 +1,14 @@
+# This runs jobs which pyiron modules should run on pushes or PRs to main
+
+name: Tests-and-Coverage with GitHub action
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pyiron:
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@df78a04
+    secrets: inherit

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@df78a04
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@coveralls
     secrets: inherit


### PR DESCRIPTION
This PR is just an indirect test, and doesn't ever actually need to be merged.