### PR TITLE
Add pyiron-data to the notebooks dependency

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -9,3 +9,4 @@ dependencies:
 - pyiron_atomistics >=0.2.63
 - python >= 3.8
 - lammps
+- pyiron-data

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -3,3 +3,4 @@ channels:
 dependencies:
   - python >= 3.8
   - lammps
+  - pyiron-data


### PR DESCRIPTION
Which I expect to resolve the following failure in the notebooks CI:

```
File /usr/share/miniconda3/envs/my-env/lib/python3.11/site-packages/pyiron_atomistics/atomistics/job/potentials.py:154, in PotentialAbstract._get_potential_df(plugin_name, file_name_lst, backward_compatibility_name)
    152     return pandas.concat(df_lst)
    153 else:
--> 154     raise ValueError("Was not able to locate the potential files.")

ValueError: Was not able to locate the potential files.
```