### PR TITLE
Pin versions to latest

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,12 +1,12 @@
 channels:
 - conda-forge
 dependencies:
-- numpy
+- numpy =1.26.3
 - openjdk
-- owlready2
-- pandas
-- pint
-- pyiron_atomistics >=0.2.63
+- owlready2 =0.45
+- pandas =2.1.4
+- pint =0.23
 - python >= 3.8
 - lammps
+- pyiron_atomistics
 - pyiron-data

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -3,4 +3,5 @@ channels:
 dependencies:
   - python >= 3.8
   - lammps
+  - pyiron_atomistics
   - pyiron-data

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -1,9 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-  - numpy
+  - numpy =1.26.3
   - openjdk
-  - owlready2
-  - pandas
-  - pint
-  - pyiron_atomistics >=0.2.63
+  - owlready2 =0.45
+  - pandas =2.1.4
+  - pint =0.23

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,9 +3,8 @@ channels:
 dependencies:
 - ipykernel
 - nbsphinx
-- numpy
+- numpy =1.26.3
 - openjdk
-- owlready2
-- pandas
-- pint
-- pyiron_atomistics >=0.2.63
+- owlready2 =0.45
+- pandas =2.1.4
+- pint =0.23

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,10 @@ setup(
     keywords='pyiron',
     packages=find_packages(exclude=["*tests*", "*docs*", "*binder*", "*conda*", "*notebooks*", "*.ci_support*"]),
     install_requires=[
-        'numpy',
-        'owlready2',
-        'pandas',
-        'pint',
-        'pyiron_atomistics>=0.2.63',
+        'numpy==1.26.3',
+        'owlready2==0.45',
+        'pandas==2.1.4',
+        'pint==0.23',
     ],
     cmdclass=versioneer.get_cmdclass(),
 


### PR DESCRIPTION
Leave the notebooks env unpinned to just grab latest -- I haven't got dependabot updating that env file yet, so safest to just let it snag the latest.