### PR TITLE
Render stuff in alphabetical order by default

### DIFF
--- a/pyiron_ontology/workflow.py
+++ b/pyiron_ontology/workflow.py
@@ -5,6 +5,8 @@
 A tree structure for ontologically-informed workflows
 """
 
+from numpy import argsort
+
 
 class NodeTree:
     def __init__(self, value, parent=None):
@@ -14,8 +16,13 @@ class NodeTree:
         if parent is not None:
             parent.children.append(self)
 
-    def render(self, depth=0):
+    def render(self, depth=0, order_alphabetically=True):
         tabs = "".join(["\t"] * depth)
         print(f"{tabs}{self.value.name}")
-        for child in self.children:
+        children = (
+            [self.children[n] for n in argsort([str(c.value) for c in self.children])]
+            if order_alphabetically
+            else self.children
+        )
+        for child in children:
             child.render(depth=depth + 1)


### PR DESCRIPTION
Consistent ordering is important for testing examples, which need reliable output. Otherwise has no real impact as it only impacts the render.