### PR TITLE
[patch] Try targeting a particular tag on the pyiron/actions repo

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Tests-and-Coverage:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-1.1.0b
     secrets: inherit
     with:
       tests-env-files: .ci_support/environment.yml .ci_support/environment-pyiron_atomistics.yml

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@main
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-1.1.0b
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@main
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-1.1.0b
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@main
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-1.1.0b
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull-main.yml@main
+    uses: pyiron/actions/.github/workflows/push-pull-main.yml@actions-1.1.0b
     secrets: inherit
     with:
       docs-env-files: .ci_support/environment.yml .ci_support/environment-docs.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/release.yml@main
+    uses: pyiron/actions/.github/workflows/release.yml@actions-1.1.0b
     secrets: inherit

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@main
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-1.1.0b
     secrets: inherit


### PR DESCRIPTION
Targeting the branch is pretty safe, because I know I put a read-only lock on the branch; but targeting the actual release tag should be inviolable. 