### PR TITLE
Use `URIRef` for the workflow-specific KG node and define pyiron namespace

### DIFF
--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -24,7 +24,7 @@ def calculate_speed(
 ) -> u(
     float,
     units="meter/second",
-    triples=((EX.isOutputOf, "inputs.time"), (EX.subject, EX.predicate, EX.object)),
+    triples=((EX.somehowRelatedTo, "inputs.time"), (EX.subject, EX.predicate, EX.object)),
 ):
     return distance / time
 
@@ -90,7 +90,7 @@ class TestParser(unittest.TestCase):
         self.assertGreater(
             len(list(graph.triples((None, PNS.hasUnits, URIRef("meter/second"))))), 0
         )
-        ex_triple = (None, EX.isOutputOf, URIRef("calculate_speed.inputs.time"))
+        ex_triple = (None, EX.somehowRelatedTo, URIRef("calculate_speed.inputs.time"))
         self.assertEqual(
             len(list(graph.triples(ex_triple))),
             1,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,6 +1,6 @@
 import unittest
 from owlrl import DeductiveClosure, OWLRL_Semantics
-from rdflib import Graph, OWL, RDF, RDFS, Literal
+from rdflib import Graph, OWL, RDF, RDFS, Literal, URIRef
 from pyiron_ontology.parser import (
     get_inputs_and_outputs,
     get_triples,
@@ -87,7 +87,7 @@ class TestParser(unittest.TestCase):
         data = get_inputs_and_outputs(speed)
         graph = get_triples(data=data, NS=NS)
         self.assertGreater(
-            len(list(graph.triples((None, NS.hasUnits, NS["meter/second"])))), 0
+            len(list(graph.triples((None, NS.hasUnits, URIRef("meter/second"))))), 0
         )
         ex_triple = (None, NS.isOutputOf, NS["calculate_speed.inputs.time"])
         self.assertEqual(
@@ -141,7 +141,7 @@ class TestParser(unittest.TestCase):
                 list(
                     graph.triples(
                         (
-                            NS["correct_analysis.addition.inputs.a"],
+                            URIRef("correct_analysis.addition.inputs.a"),
                             RDFS.label,
                             Literal("correct_analysis.addition.inputs.a"),
                         )

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -13,7 +13,8 @@ from semantikon.typing import u
 from rdflib import Namespace
 
 
-NS = Namespace("http://example.org/")
+PNS = Namespace("http://pyiron.org/ontology/")
+EX = Namespace("http://example.org/")
 
 
 @Workflow.wrap.as_function_node("speed")
@@ -23,13 +24,13 @@ def calculate_speed(
 ) -> u(
     float,
     units="meter/second",
-    triples=((NS.isOutputOf, "inputs.time"), (NS.subject, NS.predicate, NS.object)),
+    triples=((EX.isOutputOf, "inputs.time"), (EX.subject, EX.predicate, EX.object)),
 ):
     return distance / time
 
 
 @Workflow.wrap.as_function_node("result")
-def add(a: float, b: float) -> u(float, triples=(NS.HasOperation, NS.Addition)):
+def add(a: float, b: float) -> u(float, triples=(EX.HasOperation, EX.Addition)):
     return a + b
 
 
@@ -37,8 +38,8 @@ def add(a: float, b: float) -> u(float, triples=(NS.HasOperation, NS.Addition)):
 def multiply(a: float, b: float) -> u(
     float,
     triples=(
-        (NS.HasOperation, NS.Multiplication),
-        (NS.inheritsPropertiesFrom, "inputs.a"),
+        (EX.HasOperation, EX.Multiplication),
+        (PNS.inheritsPropertiesFrom, "inputs.a"),
     ),
 ):
     return a * b
@@ -49,8 +50,8 @@ def correct_analysis(
     a: u(
         float,
         restrictions=(
-            (OWL.onProperty, NS.HasOperation),
-            (OWL.someValuesFrom, NS.Addition),
+            (OWL.onProperty, EX.HasOperation),
+            (OWL.someValuesFrom, EX.Addition),
         ),
     )
 ) -> float:
@@ -62,8 +63,8 @@ def wrong_analysis(
     a: u(
         float,
         restrictions=(
-            (OWL.onProperty, NS.HasOperation),
-            (OWL.someValuesFrom, NS.Division),
+            (OWL.onProperty, EX.HasOperation),
+            (OWL.someValuesFrom, EX.Division),
         ),
     )
 ) -> float:
@@ -85,30 +86,30 @@ class TestParser(unittest.TestCase):
     def test_triples(self):
         speed = calculate_speed()
         data = get_inputs_and_outputs(speed)
-        graph = get_triples(data=data, NS=NS)
+        graph = get_triples(data=data)
         self.assertGreater(
-            len(list(graph.triples((None, NS.hasUnits, URIRef("meter/second"))))), 0
+            len(list(graph.triples((None, PNS.hasUnits, URIRef("meter/second"))))), 0
         )
-        ex_triple = (None, NS.isOutputOf, NS["calculate_speed.inputs.time"])
+        ex_triple = (None, EX.isOutputOf, URIRef("calculate_speed.inputs.time"))
         self.assertEqual(
             len(list(graph.triples(ex_triple))),
             1,
             msg=f"Triple {ex_triple} not found {graph.serialize(format='turtle')}",
         )
         self.assertEqual(
-            len(list(graph.triples((NS.subject, NS.predicate, NS.object)))), 1
+            len(list(graph.triples((EX.subject, EX.predicate, EX.object)))), 1
         )
 
     def test_correct_analysis(self):
         def get_graph(wf):
             graph = Graph()
-            graph.add((NS.HasOperation, RDF.type, RDF.Property))
-            graph.add((NS.Addition, RDF.type, OWL.Class))
-            graph.add((NS.Multiplication, RDF.type, OWL.Class))
+            graph.add((EX.HasOperation, RDF.type, RDF.Property))
+            graph.add((EX.Addition, RDF.type, OWL.Class))
+            graph.add((EX.Multiplication, RDF.type, OWL.Class))
             for value in wf.children.values():
                 data = get_inputs_and_outputs(value)
-                graph += get_triples(data=data, NS=NS)
-            _inherit_properties(graph, NS)
+                graph += get_triples(data=data)
+            _inherit_properties(graph)
             DeductiveClosure(OWLRL_Semantics).expand(graph)
             return graph
 
@@ -135,7 +136,7 @@ class TestParser(unittest.TestCase):
     def test_parse_workflow(self):
         wf = Workflow("correct_analysis")
         wf.addition = add(a=1.0, b=2.0)
-        graph = parse_workflow(wf, NS)
+        graph = parse_workflow(wf)
         self.assertEqual(
             len(
                 list(


### PR DESCRIPTION
One thing that didn't make sense at all in [this PR](https://github.com/pyiron/pyiron_ontology/pull/98) was that the user was asked to provide a namespace which was used for the workflow logic and the variable names. Now I propose to use simple `URIRef` for all workflow-specific knowledge graph nodes such as `my_workflow.my_node.inputs.my_argument`, and for all pyiron_workflow-specific objects we use a pyiron_workflow namespace, which for now I called `http://pyiron.org/ontology`, which should probably be changed later.