### PR TITLE
Remove semantikon_class condition

### DIFF
--- a/pyiron_ontology/parser.py
+++ b/pyiron_ontology/parser.py
@@ -5,6 +5,7 @@ from semantikon.converter import parse_input_args, parse_output_args, _meta_to_d
 from rdflib import Graph, Literal, RDF, RDFS, URIRef, OWL, PROV, Namespace
 from pyiron_workflow import NOT_DATA, Workflow, Macro
 from pyiron_workflow.node import Node
+from dataclasses import is_dataclass
 
 
 class PNS:
@@ -63,10 +64,6 @@ def get_inputs_and_outputs(node: Node) -> dict:
     }
 
 
-def _is_semantikon_class(dtype: type) -> bool:
-    return hasattr(dtype, "_is_semantikon_class") and dtype._is_semantikon_class
-
-
 def _translate_has_value(
     graph: Graph,
     label: URIRef,
@@ -78,13 +75,13 @@ def _translate_has_value(
 ) -> Graph:
     tag_uri = URIRef(tag + ".value")
     graph.add((label, PNS.hasValue, tag_uri))
-    if _is_semantikon_class(dtype):
+    if is_dataclass(dtype):
         warnings.warn(
             "semantikon_class is experimental - triples may change in the future",
             FutureWarning,
         )
         for k, v in dtype.__dict__.items():
-            if isinstance(v, type) and _is_semantikon_class(v):
+            if isinstance(v, type) and is_dataclass(v):
                 _translate_has_value(
                     graph=graph,
                     label=label,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -223,26 +223,23 @@ class TestParser(unittest.TestCase):
         )
 
 
-@semantikon_class
 @dataclass
 class Input:
     T: u(float, units="kelvin")
     n: int
-    # This line should be removed with the next version of semantikon
-    _is_semantikon_class = True
 
+    @dataclass
     class parameters:
-        _is_semantikon_class = True
         a: int = 2
 
+    class not_dataclass:
+        b: int = 3
 
-@semantikon_class
+
 @dataclass
 class Output:
     E: u(float, units="electron_volt")
     L: u(float, units="angstrom")
-    # This line should be removed with the next version of semantikon
-    _is_semantikon_class = True
 
 
 @Workflow.wrap.as_function_node
@@ -268,10 +265,14 @@ class TestDataclass(unittest.TestCase):
             (URIRef(o_txt), PNS.hasValue, URIRef(f"{o_txt}.E.value")),
         )
         s = graph.serialize(format="turtle")
-        for triple in triples:
-            self.assertEqual(
-                len(list(graph.triples(triple))), 1, msg=f"{triple} not found in {s}"
-            )
+        for ii, triple in enumerate(triples):
+            with self.subTest(i=ii):
+                self.assertEqual(
+                    len(list(graph.triples(triple))),
+                    1,
+                    msg=f"{triple} not found in {s}"
+                )
+        self.assertIsNone(graph.value(URIRef(f"{i_txt}.not_dataclass.b.value")))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -11,7 +11,6 @@ from pyiron_ontology.parser import (
 )
 from pyiron_workflow import Workflow
 from semantikon.typing import u
-from semantikon.converter import semantikon_class
 from dataclasses import dataclass
 from rdflib import Namespace
 
@@ -270,7 +269,7 @@ class TestDataclass(unittest.TestCase):
                 self.assertEqual(
                     len(list(graph.triples(triple))),
                     1,
-                    msg=f"{triple} not found in {s}"
+                    msg=f"{triple} not found in {s}",
                 )
         self.assertIsNone(graph.value(URIRef(f"{i_txt}.not_dataclass.b.value")))
 


### PR DESCRIPTION
It's basically the same as [this PR](https://github.com/pyiron/pyiron_ontology/pull/114), but you don't need to use `semantikon_class` anymore, but you have to use `dataclass`. For example:

```python
@dataclass
class Input:
    T: u(float, units="kelvin")
    n: int
    class parameter:
        a: int = 1

@dataclass
class Output:
    E: u(float, units="electron_volt")
    L: u(float, units="angstrom")

@Workflow.wrap.as_function_node
def run_md(inp: Input) -> Output:
    out = Output(E=1., L=2.)
    return out

inp = Input(T=300., n=3)

wf = Workflow("my_wf")
wf.node = run_md(inp)
wf.run()
```

In this case, `inp.T` and `inp.n` as well as `out.E` and `out.L` will have their values stored, while `inp.parameter.a` not, because there is no `dataclass` applied to it