### PR TITLE
Separate workflow parser from knowledge graph creation

### DIFF
--- a/pyiron_ontology/parser.py
+++ b/pyiron_ontology/parser.py
@@ -404,9 +404,36 @@ def parse_workflow(
     Returns:
         (rdflib.Graph): graph containing workflow information
     """
+    wf_dict = workflow_to_dict(workflow)
+    return get_knowledge_graph(
+        wf_dict=wf_dict,
+        graph=graph,
+        inherit_properties=inherit_properties,
+        ontology=ontology,
+        append_missing_items=append_missing_items,
+    )
+
+
+def get_knowledge_graph(
+    wf_dict: dict,
+    graph: Graph | None = None,
+    inherit_properties: bool = True,
+    ontology=PNS,
+    append_missing_items: bool = True,
+) -> Graph:
+    """
+    Generate RDF graph from a dictionary containing workflow information
+
+    Args:
+        wf_dict (dict): dictionary containing workflow information
+        graph (rdflib.Graph): graph to be updated
+        inherit_properties (bool): if True, properties are inherited
+
+    Returns:
+        (rdflib.Graph): graph containing workflow information
+    """
     if graph is None:
         graph = Graph()
-    wf_dict = workflow_to_dict(workflow)
     workflow_label = wf_dict.pop("workflow_label")
     graph.add((URIRef(workflow_label), RDFS.label, Literal(workflow_label)))
     for data in wf_dict.values():

--- a/pyiron_ontology/parser.py
+++ b/pyiron_ontology/parser.py
@@ -467,6 +467,6 @@ def _append_missing_items(graph: Graph) -> Graph:
     ):
         for obj in graph.objects(None, p):
             triple = (obj, RDF.type, o)
-            if not triple in graph:
+            if triple not in graph:
                 graph.add(triple)
     return graph


### PR DESCRIPTION
In the ongoing efforts separate workflow manager part and the creation of a knowledge graph [here](https://github.com/pyiron/pyiron_workflow/issues/576), I separated the workflow parser from the rest, so that I can move all the semantic part to `semantikon`.